### PR TITLE
fix: sort maildir emails newest-first so --limit processes recent emails

### DIFF
--- a/internal/maildir/reader.go
+++ b/internal/maildir/reader.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 )
 
@@ -41,6 +42,12 @@ func Read(maildirPath string) ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to read maildir: %w", err)
 	}
+
+	// Maildir filenames start with a Unix timestamp, so reverse-sorting
+	// by filename puts newest emails first.
+	sort.Slice(emails, func(i, j int) bool {
+		return filepath.Base(emails[i]) > filepath.Base(emails[j])
+	})
 
 	return emails, nil
 }


### PR DESCRIPTION
## Summary
- `maildir.Read()` now reverse-sorts email paths by filename, which puts newest emails first since Maildir filenames start with a Unix timestamp by convention
- When `--limit` is applied, the processor picks up the most recent emails instead of the oldest

## Test plan
- [x] Added `TestRead_ReturnsNewestFirst` verifying newest-first ordering using conventional Maildir filenames
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)