### PR TITLE
fix: use sender name for icon colors to differentiate similar emails

### DIFF
--- a/cmd/ui-server/index.html
+++ b/cmd/ui-server/index.html
@@ -196,9 +196,9 @@
         }
 
         function getColorForSender(name, email) {
-            // Use name for color generation if available, otherwise fall back to email
-            // This ensures newsletters from the same email but different names get different colors
-            const colorSource = (name && name !== email) ? name : email;
+            // Use both name and email concatenated for color generation
+            // This ensures unique colors even when newsletters share the same email
+            const colorSource = (name && name !== email) ? name + email : email;
             const hash = hashCode(colorSource);
 
             // Use golden ratio to get better distribution across hue spectrum


### PR DESCRIPTION
TLDR newsletters (AI, InfoSec, DevOps) share the same sender email but have
different sender names. The icon color generation now concatenates both the
sender name and email for hashing, ensuring visually distinct colors for
different newsletters from the same domain.

The color generation falls back to using only the email when the sender name
is absent or identical to the email address, maintaining backward compatibility
for newsletters without distinct sender names.